### PR TITLE
fix: storacha no account found error

### DIFF
--- a/packages/frontend/src/lib/__tests__/storacha.test.ts
+++ b/packages/frontend/src/lib/__tests__/storacha.test.ts
@@ -32,6 +32,7 @@ describe('storacha utilities', () => {
           claim: vi.fn().mockResolvedValue([]),
         },
       },
+      accounts: () => ({}),
     }
 
     const { create } = await import('@storacha/client')
@@ -52,6 +53,7 @@ describe('storacha utilities', () => {
           claim: vi.fn(),
         },
       },
+      accounts: () => ({}),
     }
 
     const { create } = await import('@storacha/client')
@@ -83,6 +85,28 @@ describe('storacha utilities', () => {
     })
     expect(mockClient.setCurrentSpace).toHaveBeenCalledWith('did:key:test123')
     expect(space).toBe(mockSpace)
+  })
+
+  it('reuses existing session when accounts and delegations exist', async () => {
+    const mockClient = {
+      login: vi.fn(),
+      capability: {
+        access: {
+          claim: vi.fn().mockResolvedValue([{}]),
+        },
+      },
+      accounts: () => ({ 'did:mailto:test@example.com': { did: () => '' } }),
+    }
+
+    const { create } = await import('@storacha/client')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(create).mockResolvedValue(mockClient as any)
+
+    const client = await storacha.initializeClient('test@example.com')
+
+    expect(mockClient.login).not.toHaveBeenCalled()
+    expect(mockClient.capability.access.claim).toHaveBeenCalled()
+    expect(client).toBeDefined()
   })
 
   it('reuses existing space when DID matches', async () => {

--- a/packages/frontend/src/lib/storacha.ts
+++ b/packages/frontend/src/lib/storacha.ts
@@ -38,10 +38,20 @@ export async function initializeClient(email: string): Promise<StorachaClient> {
 
     try {
       const delegations = await client.capability.access.claim()
-      if (delegations) {
+      const accounts =
+        typeof client.accounts === 'function' ? client.accounts() : {}
+      const hasDelegations = Array.isArray(delegations)
+        ? delegations.length > 0
+        : Boolean(delegations)
+
+      if (hasDelegations && Object.keys(accounts).length > 0) {
         console.log('Storacha: Existing session found and verified.')
         return client
       }
+
+      console.log(
+        'Storacha: Session exists but no accounts, starting login flow.'
+      )
     } catch {
       console.log('Storacha: No existing session, starting login flow.')
     }


### PR DESCRIPTION
# Problem founded  Storacha "No account found" Error

"Failed to create space: No Storacha account found"

Root Cause Found: Bug in initializeClient() function in /packages/frontend/src/lib/storacha.ts

## Changes:
Updated the Storacha client init flow to verify both delegations and accounts before treating a session as valid, and aligned tests with the new behavior.

Added account check + delegation length check in "storacha.ts" so we don’t return early on an empty/partial session.
Updated mocks and added a new “existing session” test in "storacha.test.ts".