### PR TITLE
fix: post-review cleanup — wallet-switch state, sort delegation, test gaps

### DIFF
--- a/packages/backend/src/__tests__/backfill.test.ts
+++ b/packages/backend/src/__tests__/backfill.test.ts
@@ -26,7 +26,7 @@ vi.mock('../config/chain.js', () => ({
   },
   MARKETPLACE_ADDRESS: '0xmarketplace',
   MARKETPLACE_ABI: [],
-  CONFIRMATIONS_REQUIRED: 5,
+  CONFIRMATIONS_REQUIRED: 2,
 }))
 
 vi.mock('../config/db.js', () => ({

--- a/packages/backend/src/__tests__/eventListner.test.ts
+++ b/packages/backend/src/__tests__/eventListner.test.ts
@@ -31,7 +31,7 @@ vi.mock('../config/chain.js', () => ({
   },
   MARKETPLACE_ADDRESS: '0xmarketplace',
   MARKETPLACE_ABI: [],
-  CONFIRMATIONS_REQUIRED: 5,
+  CONFIRMATIONS_REQUIRED: 2,
 }))
 
 vi.mock('../config/db.js', () => ({
@@ -204,7 +204,7 @@ describe('eventListener polling', () => {
     )
     expect(mockGetLogs).toHaveBeenNthCalledWith(
       3,
-      expect.objectContaining({ fromBlock: 4995n, toBlock: 5195n })
+      expect.objectContaining({ fromBlock: 4995n, toBlock: 5198n })
     )
   })
 
@@ -307,7 +307,7 @@ describe('eventListener polling', () => {
 
     expect(mockGetLogs).toHaveBeenCalledWith(
       expect.objectContaining({
-        fromBlock: 190n,
+        fromBlock: 193n,
       })
     )
   })

--- a/packages/backend/src/__tests__/listings.test.ts
+++ b/packages/backend/src/__tests__/listings.test.ts
@@ -218,4 +218,16 @@ describe('POST /api/listings', () => {
 
     expect(res.status).toBe(400)
   })
+
+  it('rejects with 403 when wallet does not match on-chain seller', async () => {
+    const differentAddress = '0x' + 'B'.repeat(40)
+
+    const res = await request(app)
+      .post('/api/listings')
+      .set('Authorization', buildAuthHeader(differentAddress))
+      .send(basePayload)
+
+    expect(res.status).toBe(403)
+    expect(res.body.error).toBe('SELLER_MISMATCH')
+  })
 })

--- a/packages/backend/src/__tests__/txVerification.test.ts
+++ b/packages/backend/src/__tests__/txVerification.test.ts
@@ -16,7 +16,7 @@ vi.mock('../config/chain.js', () => ({
   },
   MARKETPLACE_ADDRESS: '0xmarketplace',
   MARKETPLACE_ABI: [],
-  CONFIRMATIONS_REQUIRED: 5,
+  CONFIRMATIONS_REQUIRED: 2,
 }))
 
 vi.mock('viem', async (importOriginal) => {

--- a/packages/frontend/src/app/__tests__/purchases.test.ts
+++ b/packages/frontend/src/app/__tests__/purchases.test.ts
@@ -33,11 +33,13 @@ describe('Purchases page identity and ordering', () => {
     expect(pageSource).toContain('Tx: {shortValue(purchase.txHash')
   })
 
-  it('sorts purchases newest first', () => {
-    expect(pageSource).toContain('b.createdAt')
-    expect(pageSource).toContain('a.createdAt')
+  it('relies on backend ordering — no client-side sort', () => {
+    expect(pageSource).not.toMatch(/rows\.sort|\.sort\(\s*\(a,\s*b\)/)
+  })
+
+  it('re-fetches purchases when wallet address changes', () => {
     expect(pageSource).toMatch(
-      /new Date\(b\.createdAt\).*-.*new Date\(a\.createdAt\)/s
+      /useEffect\(\s*\(\)\s*=>\s*\{[\s\S]*?\},\s*\[.*address.*\]\s*\)/
     )
   })
 

--- a/packages/frontend/src/app/purchases/page.tsx
+++ b/packages/frontend/src/app/purchases/page.tsx
@@ -71,10 +71,6 @@ export default function PurchasesPage() {
 
       const json = await res.json()
       const rows: Purchase[] = json.purchases ?? []
-      rows.sort(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      )
       setPurchases(rows)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to load purchases.')
@@ -84,10 +80,12 @@ export default function PurchasesPage() {
   }
 
   useEffect(() => {
-    if (mounted && isConnected) {
+    setPurchases([])
+    setError(null)
+    if (mounted && isConnected && address) {
       fetchPurchases()
     }
-  }, [mounted, isConnected])
+  }, [mounted, isConnected, address])
 
   if (!mounted) return null
 


### PR DESCRIPTION
## Summary
Follow-up to (BETA-03 purchase freshness, BETA-06 auth cache) review I found some  gaps. 
- **Fix wallet-switch stale state**: `purchases/page.tsx` `useEffect` was missing `address` in its dependency array — stale purchase rows from the previous wallet persisted after account switch. Now clears state and re-fetches on address change.
- **Remove redundant client-side sort**: backend already returns purchases ordered `createdAt desc, id desc` — the duplicate `rows.sort()` on the frontend was unnecessary.
- **Add seller mismatch 403 route test**: the `SELLER_MISMATCH` guard on `POST /api/listings` had zero test coverage.
- **Align CONFIRMATIONS_REQUIRED mocks**: production defaults to 2, but three test files were mocking 5 — causing test assertions to use different block arithmetic than production.
## Test plan
- [x] All backend tests pass (206 passed, 4 skipped)
- [x] All frontend tests pass (173 passed)
- [x] Manual: connect wallet A → /purchases → switch to wallet B → verify purchases clear and re-fetch
- [x] Manual: disconnect wallet → verify "Connect your wallet" prompt shows
