### PR TITLE
feat(beta- 05): add --retry-failed flag and purchase recovery runbook

### DIFF
--- a/docs/runbooks/purchase-recovery.md
+++ b/docs/runbooks/purchase-recovery.md
@@ -1,0 +1,93 @@
+# Purchase backfill & recovery
+
+Quick reference for operators when on-chain purchases look missing or stuck in
+`EventLog` with `processed = false`.
+
+## When to use this
+
+- **Symptom:** Buyer paid on-chain (Base), but no matching row in `Purchase` (or
+  seller never got a notification).
+- **Stuck processing:** Rows in `EventLog` with `processed = false` (often with
+  `error` set) after a listener or RPC hiccup.
+
+Check failed rows (example with `psql` or Prisma Studio):
+
+```sql
+SELECT id, "eventType", "txHash", "blockNumber", "logIndex", processed, error
+FROM "EventLog"
+WHERE processed = false
+ORDER BY "blockNumber" ASC;
+```
+
+## How to narrow it down
+
+1. **If you have failed `EventLog` rows** — note `blockNumber` min/max; or use
+   `--retry-failed` (see below) to derive the range automatically.
+2. **If there is no row for that tx** — find the tx block in a block explorer,
+   then run a **manual** `--from` / `--to` window that includes that block (and
+   a small margin if you like).
+
+## Block ranges
+
+- **Explorer:** Open the purchase tx → block number.
+- **Auto from failures:** `--retry-failed` loads all `processed = false` rows,
+  takes `min(blockNumber)` → `max(blockNumber)`, and scans that range for
+  `PurchaseCompleted` logs.
+- **Manual:** If nothing is in `EventLog` for the gap, pick `--from` / `--to`
+  yourself around the known block.
+
+## Commands
+
+The script is `packages/backend/scripts/backfill.ts`, usually via:
+
+```bash
+pnpm --filter @marketplace/backend backfill -- <args>
+```
+
+**Dry-run first** (no DB writes, only reads + “would create” logs):
+
+```bash
+pnpm --filter @marketplace/backend backfill -- --from 1234567 --to 1234999 --dry-run
+```
+
+**Apply a specific range:**
+
+```bash
+pnpm --filter @marketplace/backend backfill -- --from 1234567 --to 1234999
+```
+
+**Retry everything that still has `processed = false` in `EventLog`:**
+
+```bash
+pnpm --filter @marketplace/backend backfill -- --retry-failed
+```
+
+**Dry-run that retry:**
+
+```bash
+pnpm --filter @marketplace/backend backfill -- --retry-failed --dry-run
+```
+
+Flags `--retry-failed` and `--from` / `--to` are **mutually exclusive**.
+
+Env: `DATABASE_URL`, RPC (e.g. `BASE_SEPOLIA_RPC_URL`) must match the chain you
+are indexing.
+
+## Safety
+
+- Processing is **idempotent**: same `txHash` + `logIndex` will not create
+  duplicate purchases; already-processed logs are skipped.
+- Safe to re-run the same range after fixing data or RPC issues.
+- On production, always **`--dry-run`** before a live run.
+
+## What “good” looks like
+
+- CLI ends without a fatal error; summary shows `Created/indexed` and/or
+  `Skipped (dedup)` as appropriate.
+- After a **live** run (not dry-run), confirm:
+  - `EventLog` for that tx has `processed = true` (or the row was replaced by a
+    successful path).
+  - `Purchase` exists for the buyer/listing and matches the on-chain tx.
+
+Use Prisma Studio (`pnpm --filter @marketplace/backend db:studio`) or SQL to
+confirm.

--- a/packages/backend/scripts/backfill.ts
+++ b/packages/backend/scripts/backfill.ts
@@ -4,6 +4,8 @@
  * Usage:
  *   pnpm --filter @marketplace/backend backfill -- --from 1000 --to 2000
  *   pnpm --filter @marketplace/backend backfill -- --from 1000 --to 2000 --dry-run
+ *   pnpm --filter @marketplace/backend backfill -- --retry-failed
+ *   pnpm --filter @marketplace/backend backfill -- --retry-failed --dry-run
  *
  * Prerequisites:
  *   - DATABASE_URL configured in .env
@@ -24,53 +26,14 @@
 import 'dotenv/config'
 
 import { disconnectDatabase } from '../src/config/db.js'
-import { backfillRange } from '../src/services/backfill.js'
+import {
+  backfillRange,
+  parseBackfillCliArgs,
+  retryFailedPurchaseBackfill,
+  type BackfillResult,
+} from '../src/services/backfill.js'
 
-function parseArgs(argv: string[]): {
-  from: bigint
-  to: bigint
-  dryRun: boolean
-} {
-  let from: bigint | null = null
-  let to: bigint | null = null
-  let dryRun = false
-
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]
-
-    if (arg === '--from' && argv[i + 1]) {
-      from = BigInt(argv[i + 1]!)
-      i++
-    } else if (arg === '--to' && argv[i + 1]) {
-      to = BigInt(argv[i + 1]!)
-      i++
-    } else if (arg === '--dry-run') {
-      dryRun = true
-    }
-  }
-
-  if (from === null || to === null) {
-    console.error(
-      'Usage: tsx scripts/backfill.ts --from <block> --to <block> [--dry-run]'
-    )
-    process.exit(1)
-  }
-
-  return { from, to, dryRun }
-}
-
-async function main() {
-  const { from, to, dryRun } = parseArgs(process.argv.slice(2))
-
-  console.log(`\n[backfill] Starting ${dryRun ? 'DRY-RUN' : 'LIVE'} backfill`)
-  console.log(`[backfill] Block range: ${from} → ${to}\n`)
-
-  const result = await backfillRange({
-    fromBlock: from,
-    toBlock: to,
-    dryRun,
-  })
-
+function printSummary(result: BackfillResult) {
   console.log('\n--- Backfill Summary ---')
   console.log(`  Mode:            ${result.dryRun ? 'DRY-RUN' : 'LIVE'}`)
   console.log(`  Block range:     ${result.fromBlock} → ${result.toBlock}`)
@@ -92,6 +55,46 @@ async function main() {
   }
 
   console.log('')
+}
+
+async function main() {
+  const parsed = parseBackfillCliArgs(process.argv.slice(2))
+
+  if (parsed.kind === 'error') {
+    console.error(parsed.message)
+    process.exit(parsed.exitCode)
+  }
+
+  if (parsed.kind === 'retry-failed') {
+    console.log(
+      `\n[backfill] Starting ${parsed.dryRun ? 'DRY-RUN' : 'LIVE'} retry of failed EventLog rows\n`
+    )
+
+    const outcome = await retryFailedPurchaseBackfill(parsed.dryRun)
+
+    if (outcome === 'empty') {
+      console.log(
+        '[backfill] No EventLog rows with processed=false. Nothing to retry.'
+      )
+      return
+    }
+
+    printSummary(outcome)
+    return
+  }
+
+  console.log(
+    `\n[backfill] Starting ${parsed.dryRun ? 'DRY-RUN' : 'LIVE'} backfill`
+  )
+  console.log(`[backfill] Block range: ${parsed.from} → ${parsed.to}\n`)
+
+  const result = await backfillRange({
+    fromBlock: parsed.from,
+    toBlock: parsed.to,
+    dryRun: parsed.dryRun,
+  })
+
+  printSummary(result)
 }
 
 main()

--- a/packages/backend/src/__tests__/backfill.test.ts
+++ b/packages/backend/src/__tests__/backfill.test.ts
@@ -5,7 +5,12 @@ import type { MockedFunction } from 'vitest'
 
 import { publicClient } from '../config/chain.js'
 import prismaDB from '../config/db.js'
-import { backfillRange } from '../services/backfill.js'
+import {
+  backfillRange,
+  findFailedEventLogsBlockRange,
+  parseBackfillCliArgs,
+  retryFailedPurchaseBackfill,
+} from '../services/backfill.js'
 
 const txPurchaseUpsert = vi.fn()
 const txEventLogUpsert = vi.fn()
@@ -34,6 +39,7 @@ vi.mock('../config/db.js', () => ({
     eventLog: {
       findFirst: vi.fn(),
       findUnique: vi.fn(),
+      findMany: vi.fn(),
     },
     $transaction: vi.fn((fn: any) =>
       fn({
@@ -83,6 +89,7 @@ beforeEach(() => {
   mockGetLogs.mockResolvedValue([])
   ;(prismaDB.eventLog.findFirst as any).mockResolvedValue(null)
   ;(prismaDB.eventLog.findUnique as any).mockResolvedValue(null)
+  ;(prismaDB.eventLog.findMany as any).mockResolvedValue([])
   txListingFind.mockResolvedValue({ id: 'listing-id' })
   txPurchaseUpsert.mockResolvedValue({ id: 'purchase-id' })
   mockDecodeEventLog.mockReturnValue({
@@ -233,5 +240,117 @@ describe('backfillRange', () => {
       expect(result.events[0]!.listingId).toBe('42')
       expect(result.events[0]!.buyer).toBe('0xbuyerAddress')
     })
+  })
+})
+
+describe('parseBackfillCliArgs', () => {
+  it('rejects --retry-failed combined with --from', () => {
+    const r = parseBackfillCliArgs(['--retry-failed', '--from', '1'])
+    expect(r.kind).toBe('error')
+    if (r.kind === 'error') {
+      expect(r.exitCode).toBe(1)
+      expect(r.message).toContain('--retry-failed')
+      expect(r.message).toContain('--from')
+    }
+  })
+
+  it('rejects --retry-failed combined with --to', () => {
+    const r = parseBackfillCliArgs(['--retry-failed', '--to', '99'])
+    expect(r.kind).toBe('error')
+    if (r.kind === 'error') {
+      expect(r.exitCode).toBe(1)
+    }
+  })
+
+  it('accepts --retry-failed with --dry-run', () => {
+    const r = parseBackfillCliArgs(['--retry-failed', '--dry-run'])
+    expect(r).toEqual({ kind: 'retry-failed', dryRun: true })
+  })
+
+  it('accepts range mode with --from and --to', () => {
+    const r = parseBackfillCliArgs(['--from', '10', '--to', '20'])
+    expect(r).toEqual({ kind: 'range', from: 10n, to: 20n, dryRun: false })
+  })
+})
+
+describe('findFailedEventLogsBlockRange', () => {
+  it('returns null when no processed=false rows', async () => {
+    ;(prismaDB.eventLog.findMany as any).mockResolvedValue([])
+    await expect(findFailedEventLogsBlockRange()).resolves.toBeNull()
+  })
+
+  it('returns min/max block across failed rows', async () => {
+    ;(prismaDB.eventLog.findMany as any).mockResolvedValue([
+      { blockNumber: 100 },
+      { blockNumber: 250 },
+      { blockNumber: 175 },
+    ])
+    await expect(findFailedEventLogsBlockRange()).resolves.toEqual({
+      count: 3,
+      fromBlock: 100n,
+      toBlock: 250n,
+    })
+  })
+})
+
+describe('retryFailedPurchaseBackfill', () => {
+  it('runs backfill over derived min/max blocks (100, 250, 175 → 100–250)', async () => {
+    ;(prismaDB.eventLog.findMany as any).mockResolvedValue([
+      { blockNumber: 100 },
+      { blockNumber: 250 },
+      { blockNumber: 175 },
+    ])
+    mockGetLogs.mockResolvedValue([])
+
+    const out = await retryFailedPurchaseBackfill(false)
+    expect(out).not.toBe('empty')
+    if (out !== 'empty') {
+      expect(out.fromBlock).toBe(100n)
+      expect(out.toBlock).toBe(250n)
+    }
+    expect(mockGetLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromBlock: 100n,
+        toBlock: 250n,
+      })
+    )
+  })
+
+  it('does not scan chain when no failed events', async () => {
+    ;(prismaDB.eventLog.findMany as any).mockResolvedValue([])
+
+    const out = await retryFailedPurchaseBackfill(false)
+    expect(out).toBe('empty')
+    expect(mockGetLogs).not.toHaveBeenCalled()
+  })
+
+  it('retry dry-run uses same block window with dry-run scan (getLogs, no writes)', async () => {
+    ;(prismaDB.eventLog.findMany as any).mockResolvedValue([
+      { blockNumber: 100 },
+    ])
+    mockGetLogs.mockResolvedValue([])
+
+    await retryFailedPurchaseBackfill(true)
+    expect(mockGetLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromBlock: 100n,
+        toBlock: 100n,
+      })
+    )
+  })
+
+  it('dry-run retry uses backfillRange with dryRun so there are no DB writes', async () => {
+    mockGetLogs.mockResolvedValue([makeMockLog()])
+    ;(prismaDB.eventLog.findMany as any).mockResolvedValue([
+      { blockNumber: 1500 },
+    ])
+
+    const out = await retryFailedPurchaseBackfill(true)
+    expect(out).not.toBe('empty')
+    if (out !== 'empty') {
+      expect(out.dryRun).toBe(true)
+    }
+    expect(txPurchaseUpsert).not.toHaveBeenCalled()
+    expect(txEventLogUpsert).not.toHaveBeenCalled()
   })
 })

--- a/packages/backend/src/__tests__/backfill.test.ts
+++ b/packages/backend/src/__tests__/backfill.test.ts
@@ -162,8 +162,9 @@ describe('backfillRange', () => {
     const result = await backfillRange({ fromBlock: 1000n, toBlock: 1500n })
 
     expect(result.eventsFound).toBe(1)
-    expect(result.eventsCreated).toBe(1)
-    expect(result.eventsSkipped).toBe(0)
+    expect(result.eventsCreated).toBe(0)
+    expect(result.eventsSkipped).toBe(1)
+    expect(result.events[0]!.status).toBe('skipped')
     expect(txPurchaseUpsert).not.toHaveBeenCalled()
   })
 
@@ -289,6 +290,19 @@ describe('findFailedEventLogsBlockRange', () => {
       count: 3,
       fromBlock: 100n,
       toBlock: 250n,
+    })
+  })
+
+  it('queries only failed PurchaseCompleted event rows', async () => {
+    ;(prismaDB.eventLog.findMany as any).mockResolvedValue([
+      { blockNumber: 100 },
+    ])
+
+    await findFailedEventLogsBlockRange()
+
+    expect(prismaDB.eventLog.findMany).toHaveBeenCalledWith({
+      where: { processed: false, eventType: 'PurchaseCompleted' },
+      select: { blockNumber: true },
     })
   })
 })

--- a/packages/backend/src/services/backfill.ts
+++ b/packages/backend/src/services/backfill.ts
@@ -212,3 +212,114 @@ export async function backfillRange(
 
   return result
 }
+
+/** Rows in EventLog with processed=false (failed or never completed). */
+export async function findFailedEventLogsBlockRange(): Promise<{
+  count: number
+  fromBlock: bigint
+  toBlock: bigint
+} | null> {
+  const rows = await prismaDB.eventLog.findMany({
+    where: { processed: false },
+    select: { blockNumber: true },
+  })
+
+  if (rows.length === 0) {
+    return null
+  }
+
+  const blockNumbers = rows.map((r) => r.blockNumber)
+  const minBlock = Math.min(...blockNumbers)
+  const maxBlock = Math.max(...blockNumbers)
+
+  return {
+    count: rows.length,
+    fromBlock: BigInt(minBlock),
+    toBlock: BigInt(maxBlock),
+  }
+}
+
+/**
+ * Re-scan the chain for PurchaseCompleted logs in the block range covering
+ * all EventLog rows with processed=false.
+ */
+export async function retryFailedPurchaseBackfill(
+  dryRun: boolean
+): Promise<BackfillResult | 'empty'> {
+  const range = await findFailedEventLogsBlockRange()
+
+  if (!range) {
+    return 'empty'
+  }
+
+  console.log(
+    `[backfill] Found ${range.count} failed event(s) (processed=false). Derived block range: ${range.fromBlock} → ${range.toBlock}`
+  )
+
+  return backfillRange({
+    fromBlock: range.fromBlock,
+    toBlock: range.toBlock,
+    dryRun,
+  })
+}
+
+export type ParsedBackfillCli =
+  | {
+      kind: 'range'
+      from: bigint
+      to: bigint
+      dryRun: boolean
+    }
+  | { kind: 'retry-failed'; dryRun: boolean }
+  | { kind: 'error'; message: string; exitCode: number }
+
+/**
+ * Parse argv for scripts/backfill.ts (--from/--to range vs --retry-failed).
+ */
+export function parseBackfillCliArgs(argv: string[]): ParsedBackfillCli {
+  let from: bigint | null = null
+  let to: bigint | null = null
+  let dryRun = false
+  let retryFailed = false
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+
+    if (arg === '--from' && argv[i + 1]) {
+      from = BigInt(argv[i + 1]!)
+      i++
+    } else if (arg === '--to' && argv[i + 1]) {
+      to = BigInt(argv[i + 1]!)
+      i++
+    } else if (arg === '--dry-run') {
+      dryRun = true
+    } else if (arg === '--retry-failed') {
+      retryFailed = true
+    }
+  }
+
+  if (retryFailed && (from !== null || to !== null)) {
+    return {
+      kind: 'error',
+      message:
+        'Error: --retry-failed cannot be used together with --from or --to. Use one mode or the other.',
+      exitCode: 1,
+    }
+  }
+
+  if (retryFailed) {
+    return { kind: 'retry-failed', dryRun }
+  }
+
+  if (from === null || to === null) {
+    return {
+      kind: 'error',
+      message:
+        'Usage: tsx scripts/backfill.ts --from <block> --to <block> [--dry-run]\n' +
+        '   or: tsx scripts/backfill.ts --retry-failed [--dry-run]',
+      exitCode: 1,
+    }
+  }
+
+  return { kind: 'range', from, to, dryRun }
+}

--- a/packages/backend/src/services/backfill.ts
+++ b/packages/backend/src/services/backfill.ts
@@ -1,11 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { decodeEventLog } from 'viem'
-
-import {
-  publicClient,
-  MARKETPLACE_ABI,
-  MARKETPLACE_ADDRESS,
-} from '../config/chain.js'
+import { publicClient, MARKETPLACE_ADDRESS } from '../config/chain.js'
 import prismaDB from '../config/db.js'
 
 import {
@@ -14,6 +8,7 @@ import {
   processLog,
   withRetry,
 } from './eventListener.js'
+import { parsePurchaseCompletedEvent } from './eventParsing.js'
 
 export interface BackfillOptions {
   fromBlock: bigint
@@ -61,13 +56,7 @@ async function inspectLog(log: any): Promise<{
     where: { txHash_logIndex: { txHash, logIndex } },
   })
 
-  const decoded = decodeEventLog({
-    abi: MARKETPLACE_ABI,
-    data: log.data,
-    topics: log.topics,
-  })
-
-  const { listingId, buyer, amountUsdc } = decoded.args as any
+  const { listingId, buyer, amountUsdc } = parsePurchaseCompletedEvent(log)
 
   return {
     txHash,
@@ -174,10 +163,14 @@ export async function backfillRange(
         const logIndex: number = log.logIndex
 
         try {
-          await processLog(log)
+          const status = await processLog(log)
 
           const info = await inspectLog(log)
-          result.eventsCreated++
+          if (status === 'created') {
+            result.eventsCreated++
+          } else {
+            result.eventsSkipped++
+          }
           result.events.push({
             txHash,
             logIndex,
@@ -185,7 +178,7 @@ export async function backfillRange(
             listingId: info.listingId,
             buyer: info.buyer,
             amountUsdc: info.amountUsdc,
-            status: 'created',
+            status,
           })
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error)
@@ -220,7 +213,7 @@ export async function findFailedEventLogsBlockRange(): Promise<{
   toBlock: bigint
 } | null> {
   const rows = await prismaDB.eventLog.findMany({
-    where: { processed: false },
+    where: { processed: false, eventType: 'PurchaseCompleted' },
     select: { blockNumber: true },
   })
 

--- a/packages/backend/src/services/eventListener.ts
+++ b/packages/backend/src/services/eventListener.ts
@@ -1,14 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { decodeEventLog } from 'viem'
-
 import {
   publicClient,
-  MARKETPLACE_ABI,
   MARKETPLACE_ADDRESS,
   CONFIRMATIONS_REQUIRED,
 } from '../config/chain.js'
 import prismaDB from '../config/db.js'
 
+import { parsePurchaseCompletedEvent } from './eventParsing.js'
 import { notifySeller } from './notification.js'
 
 const POLL_INTERVAL_MS = 8_000
@@ -100,10 +98,10 @@ export async function recordFailedEvent(
   }
 }
 
-export async function processLog(log: any): Promise<void> {
+export async function processLog(log: any): Promise<'created' | 'skipped'> {
   if (log.blockNumber == null || !log.transactionHash || log.logIndex == null) {
     console.warn('[listener] Skipping log with missing fields')
-    return
+    return 'skipped'
   }
 
   const blockNumber = Number(log.blockNumber)
@@ -117,16 +115,11 @@ export async function processLog(log: any): Promise<void> {
   })
 
   if (alreadyProcessed?.processed) {
-    return
+    return 'skipped'
   }
 
-  const decoded = decodeEventLog({
-    abi: MARKETPLACE_ABI,
-    data: log.data,
-    topics: log.topics,
-  })
-
-  const { listingId, buyer, seller, amountUsdc } = decoded.args as any
+  const { listingId, buyer, seller, amountUsdc } =
+    parsePurchaseCompletedEvent(log)
 
   console.log(
     `[listener] Processing purchase: listing=${listingId}, block=${blockNumber}, tx=${txHash}`
@@ -171,6 +164,8 @@ export async function processLog(log: any): Promise<void> {
     seller,
     purchaseId: purchase.id,
   })
+
+  return 'created'
 }
 
 export async function pollOnce(): Promise<void> {

--- a/packages/backend/src/services/eventParsing.ts
+++ b/packages/backend/src/services/eventParsing.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { decodeEventLog } from 'viem'
+
+import { MARKETPLACE_ABI } from '../config/chain.js'
+
+export interface ParsedPurchaseCompletedEvent {
+  listingId: string
+  buyer: string
+  seller: string
+  amountUsdc: string
+}
+
+export function parsePurchaseCompletedEvent(log: {
+  data: unknown
+  topics: unknown
+}): ParsedPurchaseCompletedEvent {
+  const decoded = decodeEventLog({
+    abi: MARKETPLACE_ABI,
+    data: log.data as any,
+    topics: log.topics as any,
+  })
+
+  const { listingId, buyer, seller, amountUsdc } = decoded.args as any
+
+  return {
+    listingId: listingId.toString(),
+    buyer: buyer as string,
+    seller: seller as string,
+    amountUsdc: amountUsdc.toString(),
+  }
+}


### PR DESCRIPTION
This adds a --retry-failed mode to the existing backfill CLI so operators can re-scan the chain for PurchaseCompleted logs over the block range implied by EventLog rows that still have processed: false. We take min(blockNumber) and max(blockNumber) across those rows, log how many failures that is and the derived range, then call the same backfillRange() as the manual path—so behavior stays idempotent and --dry-run still means no writes.

**Why:** When the listener or RPC flakes, rows can sit unprocessed; this avoids hand-calculating block numbers when you already have failure rows in the DB.

**Guardrails:** --retry-failed cannot be combined with --from / --to (clear error, exit 1). If there are no processed: false rows, we print that and exit 0 without calling backfillRange. The script still uses --from / --to for explicit ranges (unchanged).

**Tests:** Extended backfill.test.ts for CLI parsing, derived min/max blocks, empty case (no getLogs), and dry-run retry (no purchase/event writes).

**Docs:** docs/runbooks/purchase-recovery.md — when to use it, how to inspect EventLog, example commands, safety, and how to confirm success.

Fixes #37 
